### PR TITLE
If there is no "locality" name, use "administrative_area_level_3" as city name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 listings/
 *.inf
+/.idea/

--- a/GenerateInfFile.py
+++ b/GenerateInfFile.py
@@ -19,7 +19,7 @@ def getAddressMap():
     ans['lat'] = str(latlng['lat'])
     ans['lng'] = str(latlng['lng'])
     postalCode = [item for item in json.loads(resp.text)['results'][0]['address_components'] if "postal_code" in item['types'] ][0]['short_name']
-    city = [item for item in json.loads(resp.text)['results'][0]['address_components'] if "locality" in item['types'] ][0]['short_name']
+    city = [item for item in json.loads(resp.text)['results'][0]['address_components'] if "administrative_area_level_3" in item['types'] or "locality" in item['types'] ][0]['short_name']
     province = [item for item in json.loads(resp.text)['results'][0]['address_components'] if "administrative_area_level_1" in item['types'] ][0]['short_name']
     ans['postal_code'] = postalCode
     ans['city'] = city


### PR DESCRIPTION
In rural regions, sometimes there is no "locality" in the json data... so the script craches.